### PR TITLE
Add CommissionRate

### DIFF
--- a/src/FirstGivingDonation.php
+++ b/src/FirstGivingDonation.php
@@ -61,6 +61,7 @@ class FirstGivingDonation {
 	private $merchantId = null;
 	private $merchantEmail = null;
 	private $merchantName = null;
+	private $commissionRate = null;
 
 	/**
 	 * @return the $attributionType
@@ -421,4 +422,18 @@ class FirstGivingDonation {
 		$this->recurringBillingAmount = $recurringBillingAmount;
 	}
 
+	/**
+	 * @return the $commissionRate
+	 */
+	public function getCommissionRate() {
+		return $this->commissionRate;
+	}
+
+	/**
+	 * @param $commissionRate the $commissionRate to set
+	 */
+	public function setCommissionRate($commissionRate) {
+		$this->commissionRate = $commissionRate;
+	}
+	
 }


### PR DESCRIPTION
The commissionRate option was not present in the SDK.

I added it.

This is the way to use it.

```
$donation = new FirstGivingDonation();
$donation->setCommissionRate($commissionRate);
```

commissionRate – (optional) The total processing fee percentage to be withheld from the donation. For example, pass “7.5” to have for $7.50 withheld from a $100 donation. This must be greater than the FirstGiving fee (4.25%) and less than the maximum fee configured at the time of setup. If not passed, the maximum value is used.


Maybe the owner of the project didn't see my pull request so I made one again.